### PR TITLE
Fix parsing of masks from existing MDIN input

### DIFF
--- a/src/MdinFile.cpp
+++ b/src/MdinFile.cpp
@@ -43,7 +43,7 @@ MdinFile::StatType MdinFile::TokenizeLine(TokenArray& Tokens, std::string const&
             return NEW_NAMELIST;
           }
         } else {
-          size_t found = elt.find_last_of("=");
+          size_t found = elt.find_first_of("=");
           if (found == std::string::npos) {
             ErrorMsg("Namelist token does not contain '=': %s\n", elt.c_str());
             return ERR;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@
 using namespace Messages;
 using namespace FileRoutines;
 
-static const char* VERSION = "1.06";
+static const char* VERSION = "1.07";
 
 static void CmdLineHelp() {
   Msg("Command line options:\n"


### PR DESCRIPTION
Version 1.07. When identifying `<var> = <value>` pairs, the code was previously looking for the last instance of `=`, which would cause things like `restraint_mask = :1-10&!@H=` to be parsed incorrectly. This PR fixes that behavior by looking for the first instance of `=`.